### PR TITLE
Fixed model configs

### DIFF
--- a/repository/T5-base-for-BioQA.json
+++ b/repository/T5-base-for-BioQA.json
@@ -3,7 +3,8 @@
   "type": ["abstractive"],
   "description": "Google's T5-base fine-tuned on BioASQ (secondary task) for Q&A downstream task.",
   "downloads": 172,
-  "dataset":["bioasq"],
+  "dataset": ["squad"],
+  "columns": [["question", "context"]],
   "domain": ["bio"],
   "task": "question-answering"
 }

--- a/repository/roberta-base-fiqa-flm-sq-flit.json
+++ b/repository/roberta-base-fiqa-flm-sq-flit.json
@@ -3,7 +3,8 @@
   "type": ["extractive"],
   "description": "This model is a fine-tuned version of roberta-base on a custom dataset create for question answering in financial domain. The model is intended to be used for a custom Questions Answering system in the BFSI domain.",
   "downloads": 172,
-  "dataset":["BeIR/fiqa", "squad"],
+  "dataset": ["squad"],
+  "columns": [["question", "context"]],
   "domain": ["math", "finance"],
   "task": "question-answering"
 }

--- a/repository/t5-base-finetuned-question-answering.json
+++ b/repository/t5-base-finetuned-question-answering.json
@@ -3,7 +3,9 @@
   "type": ["abstractive"],
   "description": "This model is the result produced by Christian Di Maio and Giacomo Nunziati for the Language Processing Technologies exam. Reference for Google's T5 fine-tuned on DuoRC for Generative Question Answering by just prepending the question to the context. The DuoRC dataset is an English language dataset of questions and answers gathered from crowdsourced AMT workers on Wikipedia and IMDb movie plots. The workers were given freedom to pick answer from the plots or synthesize their own answers. It contains two sub-datasets - SelfRC and ParaphraseRC. SelfRC dataset is built on Wikipedia movie plots solely. ParaphraseRC has questions written from Wikipedia movie plots and the answers are given based on corresponding IMDb movie plots.",
   "downloads": 4447,
-  "dataset":["duorc", "squad"],
+  "dataset": ["duorc", "squad"],
+  "configs": [["SelfRC", "ParaphraseRC"], []],
+  "columns": [["question", "plot"], ["question", "context"]],
   "domain": ["narrative"],
   "task": "question-answering"
 }


### PR DESCRIPTION
The duorc dataset requires a config (as the second argument to load_dataset()), so I added an optional column for it. Hopefully this can work well with the rest of our jsons. Both configs are useful and both have the same columns